### PR TITLE
Engage CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: perl:5.20.3
+    steps:
+      - checkout
+      - run:
+          name: "Install CPAN deps"
+          command: |
+            export PERL_MM_USE_DEFAULT=1
+            cpan Crypt::CFB
+            cpan Crypt::Ctr
+            cpan Digest::CMAC
+            cpan Moose
+            cpan Test::Exception
+            cpan Test::use::ok
+            cpan namespace::clean
+            perl Makefile.PL
+            make
+      - run:
+          name: "Run Test Suite"
+          command: |
+            make test
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.*
 !.gitignore
 Makefile*
 !Makefile.PL

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+Crypt::EAX
+==========
+
+To build, test and install:
+
+    perl Makefile.PL
+    make
+    make test
+    make install


### PR DESCRIPTION
Add a CircleCI config which runs the usual `perl Makefile.PL; make test` routine.

Unless we go get a patched version of Crypt::CFB, we're stuck on an old version of Perl.  Crypt::CFB has this line in it, which hasn't worked in years:
```
use UNIVERSAL qw(can);
```